### PR TITLE
fixed email transcript again, use id instead of code

### DIFF
--- a/src/components/chat-component/Chat.jsx
+++ b/src/components/chat-component/Chat.jsx
@@ -83,8 +83,6 @@ function clearSessionAndNavigate(){
     // Clear the messages when the session ends
     setMessages([]);
     sessionStorage.removeItem("chatMessages");
-    sessionStorage.removeItem("sessionId");
-    sessionStorage.removeItem("sessionCode");
     unsubscribeToEndSession(sessionEnded);
 
     endSessionWebsocket();

--- a/src/components/end-session-component/EndSession.jsx
+++ b/src/components/end-session-component/EndSession.jsx
@@ -16,7 +16,7 @@ import {
 
 function EndSession() {
     const emailRef = useRef();
-    const sessionCode = sessionStorage.getItem("sessionCode");
+    const sessionId = sessionStorage.getItem("sessionId");
     const [success, setSuccess] = useState(false);
     const [error, setError] = useState(false);
 
@@ -27,8 +27,8 @@ function EndSession() {
         const templateId = "template_feo851p";
 
         // TODO: change to azure endpoint
-        let transcriptUrl = 'http://localhost:8080/email/transcript/' + sessionCode
-        let dateUrl = 'http://localhost:8080/email/date/' + sessionCode
+        let transcriptUrl = 'http://localhost:8080/email/transcript/' + sessionId
+        let dateUrl = 'http://localhost:8080/email/date/' + sessionId
 
         try {
             const response = await axios.get(transcriptUrl);


### PR DESCRIPTION
# Description

Email transcript broke after the changes to EndSession. I fixed it by getting by Id instead.

Fixes # (issue)
Stopped Chat from deleting id and code from SessionStorage again!

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Manual tests

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
