### PR TITLE
stopped chat.jsx from deleting sessionid again :(

### DIFF
--- a/src/components/chat-component/Chat.jsx
+++ b/src/components/chat-component/Chat.jsx
@@ -84,7 +84,6 @@ function clearSessionAndNavigate(){
     // Clear the messages when the session ends
     setMessages([]);
     sessionStorage.removeItem("chatMessages");
-    sessionStorage.removeItem("sessionId");
     sessionStorage.removeItem("sessionCode");
     localStorage.removeItem("isSessionActive");
     unsubscribeToEndSession(sessionEnded);

--- a/src/components/enter-code-component/EnterCode.jsx
+++ b/src/components/enter-code-component/EnterCode.jsx
@@ -58,7 +58,7 @@ function EnterCode() {
             <CodeContainer>
                 <Text>Enter your session code</Text>
                 <InputSection>
-                    <Input placeholder="ex. abcd123" 
+                    <Input placeholder="ex. ABCDEF" 
                         onKeyPress={handleKeyPress} onChange={handleInputChange}/>
                     <Button onClick={joinSession}>Connect</Button>
                 </InputSection>


### PR DESCRIPTION
# Description

Email transcript is back /:D
stopped chat.jsx from deleting sessionid again :(
changed placeholder text from abc123 to ABCDEF

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Email transcript works now.

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings